### PR TITLE
[FEAT/BE] 프로그램에 대한 참석자 정보 가져오는 API 구현

### DIFF
--- a/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/dto/AttendInfoResponse.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/dto/AttendInfoResponse.java
@@ -1,0 +1,18 @@
+package com.blackcompany.eeos.attend.application.dto;
+
+import com.blackcompany.eeos.common.support.dto.AbstractResponseDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class AttendInfoResponse implements AbstractResponseDto {
+	private Long id;
+	private Long generation;
+	private String name;
+	private String attendStatus;
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/dto/converter/AttendInfoConverter.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/dto/converter/AttendInfoConverter.java
@@ -1,0 +1,18 @@
+package com.blackcompany.eeos.attend.application.dto.converter;
+
+import com.blackcompany.eeos.attend.application.dto.AttendInfoResponse;
+import com.blackcompany.eeos.member.application.model.MemberModel;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AttendInfoConverter {
+	public AttendInfoResponse from(final MemberModel target, final String attendStatus) {
+		return AttendInfoResponse
+				.builder()
+				.id(target.getId())
+				.generation(target.getGeneration())
+				.name(target.getName())
+				.attendStatus(attendStatus)
+				.build();
+	}
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/exception/NotFoundMemberException.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/exception/NotFoundMemberException.java
@@ -1,0 +1,11 @@
+package com.blackcompany.eeos.attend.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundMemberException extends BusinessException {
+
+	public NotFoundMemberException(String message) {
+		super(message, HttpStatus.NOT_FOUND);
+	}
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/model/AttendModel.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/model/AttendModel.java
@@ -1,0 +1,19 @@
+package com.blackcompany.eeos.attend.application.model;
+
+import com.blackcompany.eeos.common.support.AbstractModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class AttendModel implements AbstractModel {
+	private Long id;
+	private Long memberId;
+	private Long programId;
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/model/AttendStatus.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/model/AttendStatus.java
@@ -1,0 +1,17 @@
+package com.blackcompany.eeos.attend.application.model;
+
+public enum AttendStatus {
+	PARTICIPATE("participate"),
+	NON_PARITICPATE("non-participate"),
+	NONE("none");
+
+	private final String status;
+
+	AttendStatus(String status) {
+		this.status = status;
+	}
+
+	public String getStatus() {
+		return this.status;
+	}
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/model/converter/AttendEntityConverter.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/model/converter/AttendEntityConverter.java
@@ -1,0 +1,32 @@
+package com.blackcompany.eeos.attend.application.model.converter;
+
+import com.blackcompany.eeos.attend.application.model.AttendModel;
+import com.blackcompany.eeos.attend.persistence.AttendEntity;
+import com.blackcompany.eeos.common.support.converter.AbstractEntityConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AttendEntityConverter implements AbstractEntityConverter<AttendEntity, AttendModel> {
+
+	@Override
+	public AttendModel from(AttendEntity source) {
+		return AttendModel.builder()
+				.id(source.getId())
+				.memberId(source.getMemberId())
+				.programId(source.getProgramId())
+				.build();
+	}
+
+	@Override
+	public AttendEntity toEntity(AttendModel source) {
+		return AttendEntity.builder()
+				.id(source.getId())
+				.memberId(source.getMemberId())
+				.programId(source.getProgramId())
+				.build();
+	}
+
+	public AttendEntity toEntity(Long memberId, Long programId) {
+		return AttendEntity.builder().memberId(memberId).programId(programId).build();
+	}
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/service/AttendService.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/service/AttendService.java
@@ -1,0 +1,32 @@
+package com.blackcompany.eeos.attend.application.service;
+
+import com.blackcompany.eeos.attend.application.dto.AttendInfoResponse;
+import com.blackcompany.eeos.attend.application.dto.converter.AttendInfoConverter;
+import com.blackcompany.eeos.attend.application.usecase.GetAttendantInfoUsecase;
+import com.blackcompany.eeos.attend.persistence.AttendEntity;
+import com.blackcompany.eeos.attend.persistence.AttendRepository;
+import com.blackcompany.eeos.member.application.service.MemberService;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AttendService implements GetAttendantInfoUsecase {
+	private final AttendRepository attendRepository;
+	private final MemberService memberService;
+	private final AttendInfoConverter infoConverter;
+	
+	@Override
+	public List<AttendInfoResponse> findAttendInfo(final Long programId) {
+		List<AttendEntity> attendEntities = attendRepository.findAllByProgramId(programId);
+		return attendEntities.stream()
+				.map(
+						attendEntity ->
+								infoConverter.from(
+										memberService.findMemberInfo(attendEntity.getId()),
+										attendEntity.getStatus().getStatus()))
+				.collect(Collectors.toList());
+	}
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/service/CandidateService.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/service/CandidateService.java
@@ -1,0 +1,5 @@
+package com.blackcompany.eeos.attend.application.service;
+
+public interface CandidateService {
+	void saveCandidate(final Long programId);
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/service/DefaultCandidateService.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/service/DefaultCandidateService.java
@@ -1,0 +1,30 @@
+package com.blackcompany.eeos.attend.application.service;
+
+import com.blackcompany.eeos.attend.application.model.converter.AttendEntityConverter;
+import com.blackcompany.eeos.attend.persistence.AttendEntity;
+import com.blackcompany.eeos.attend.persistence.AttendRepository;
+import com.blackcompany.eeos.member.application.service.MemberService;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DefaultCandidateService implements CandidateService {
+	private final AttendEntityConverter entityConverter;
+	private final MemberService memberService;
+	private final AttendRepository attendRepository;
+
+	@Override
+	public void saveCandidate(final Long programId) {
+		List<AttendEntity> attendEntities =
+				memberService.findAllMember().stream()
+						.map(memberModel -> entityConverter.toEntity(memberModel.getId(), programId))
+						.collect(Collectors.toList());
+
+		attendRepository.saveAll(attendEntities);
+	}
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/usecase/GetAttendantInfoUsecase.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/attend/application/usecase/GetAttendantInfoUsecase.java
@@ -1,0 +1,10 @@
+package com.blackcompany.eeos.attend.application.usecase;
+
+import com.blackcompany.eeos.attend.application.dto.AttendInfoResponse;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public interface GetAttendantInfoUsecase {
+	List<AttendInfoResponse> findAttendInfo(Long programId);
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/attend/persistence/AttendEntity.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/attend/persistence/AttendEntity.java
@@ -1,0 +1,46 @@
+package com.blackcompany.eeos.attend.persistence;
+
+import com.blackcompany.eeos.attend.application.model.AttendStatus;
+import com.blackcompany.eeos.common.persistence.BaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
+@SuperBuilder(toBuilder = true)
+@Entity
+@Table(name = AttendEntity.ENTITY_PREFIX)
+public class AttendEntity extends BaseEntity {
+	public static final String ENTITY_PREFIX = "attend";
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = ENTITY_PREFIX + "_id", nullable = false)
+	private Long id;
+
+	@Column(name = ENTITY_PREFIX + "_program_id", nullable = false)
+	private Long programId;
+
+	@Column(name = ENTITY_PREFIX + "_member_id", nullable = false)
+	private Long memberId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = ENTITY_PREFIX + "_status", nullable = false)
+	@Builder.Default
+	private AttendStatus status = AttendStatus.NONE;
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/attend/persistence/AttendRepository.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/attend/persistence/AttendRepository.java
@@ -1,0 +1,8 @@
+package com.blackcompany.eeos.attend.persistence;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AttendRepository extends JpaRepository<AttendEntity, Long> {
+	List<AttendEntity> findAllByProgramId(Long programId);
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/attend/presentation/AttendController.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/attend/presentation/AttendController.java
@@ -1,0 +1,29 @@
+package com.blackcompany.eeos.attend.presentation;
+
+import com.blackcompany.eeos.attend.application.dto.AttendInfoResponse;
+import com.blackcompany.eeos.attend.application.usecase.GetAttendantInfoUsecase;
+import com.blackcompany.eeos.common.presentation.respnose.ApiResponse;
+import com.blackcompany.eeos.common.presentation.respnose.ApiResponseBody.SuccessBody;
+import com.blackcompany.eeos.common.presentation.respnose.ApiResponseGenerator;
+import com.blackcompany.eeos.common.presentation.respnose.MessageCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/attend/candidate")
+public class AttendController {
+	private final GetAttendantInfoUsecase getAttendantInfoUsecase;
+
+	@GetMapping("/program/{programId}")
+	public ApiResponse<SuccessBody<List<AttendInfoResponse>>> findAttendMemberInfo(
+			@PathVariable("programId") Long programId) {
+		List<AttendInfoResponse> response = getAttendantInfoUsecase.findAttendInfo(programId);
+		return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.GET);
+	}
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/member/application/model/MemberModel.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/member/application/model/MemberModel.java
@@ -1,0 +1,19 @@
+package com.blackcompany.eeos.member.application.model;
+
+import com.blackcompany.eeos.common.support.AbstractModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class MemberModel implements AbstractModel {
+	private Long id;
+	private String name;
+	private Long generation;
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/member/application/model/converter/MemberEntityConverter.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/member/application/model/converter/MemberEntityConverter.java
@@ -1,0 +1,28 @@
+package com.blackcompany.eeos.member.application.model.converter;
+
+import com.blackcompany.eeos.common.support.converter.AbstractEntityConverter;
+import com.blackcompany.eeos.member.application.model.MemberModel;
+import com.blackcompany.eeos.member.persistence.MemberEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberEntityConverter implements AbstractEntityConverter<MemberEntity, MemberModel> {
+
+	@Override
+	public MemberModel from(MemberEntity source) {
+		return MemberModel.builder()
+				.id(source.getId())
+				.name(source.getName())
+				.generation(source.getGeneration())
+				.build();
+	}
+
+	@Override
+	public MemberEntity toEntity(MemberModel source) {
+		return MemberEntity.builder()
+				.id(source.getId())
+				.name(source.getName())
+				.generation(source.getGeneration())
+				.build();
+	}
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/member/application/service/MemberService.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/member/application/service/MemberService.java
@@ -1,0 +1,33 @@
+package com.blackcompany.eeos.member.application.service;
+
+import com.blackcompany.eeos.attend.application.exception.NotFoundMemberException;
+import com.blackcompany.eeos.member.application.model.MemberModel;
+import com.blackcompany.eeos.member.application.model.converter.MemberEntityConverter;
+import com.blackcompany.eeos.member.persistence.MemberEntity;
+import com.blackcompany.eeos.member.persistence.MemberRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+	private final MemberEntityConverter entityConverter;
+	private final MemberRepository memberRepository;
+
+	public List<MemberModel> findAllMember() {
+		return memberRepository.findAll().stream()
+				.map(entityConverter::from)
+				.collect(Collectors.toList());
+	}
+
+	public MemberModel findMemberInfo(final Long memberId) {
+		MemberEntity entity =
+				memberRepository
+						.findById(memberId)
+						.orElseThrow(() -> new NotFoundMemberException("존재하지 않는 멤버입니다."));
+
+		return entityConverter.from(entity);
+	}
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/member/persistence/MemberEntity.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/member/persistence/MemberEntity.java
@@ -1,0 +1,37 @@
+package com.blackcompany.eeos.member.persistence;
+
+import com.blackcompany.eeos.common.persistence.BaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
+@SuperBuilder(toBuilder = true)
+@Entity
+@Table(name = MemberEntity.ENTITY_PREFIX)
+public class MemberEntity extends BaseEntity {
+	public static final String ENTITY_PREFIX = "member";
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = ENTITY_PREFIX + "_id", nullable = false)
+	private Long id;
+
+	@Column(name = ENTITY_PREFIX + "_name", nullable = false)
+	private String name;
+
+	@Column(name = ENTITY_PREFIX + "_generation", nullable = false)
+	private Long generation;
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/member/persistence/MemberRepository.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/member/persistence/MemberRepository.java
@@ -1,0 +1,5 @@
+package com.blackcompany.eeos.member.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<MemberEntity, Long> {}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/program/application/dto/converter/ProgramResponseConverter.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/program/application/dto/converter/ProgramResponseConverter.java
@@ -20,6 +20,6 @@ public class ProgramResponseConverter {
 	}
 
 	public CommandProgramResponse from(Long id) {
-		return CommandProgramResponse.builder().id(id).build();
+		return CommandProgramResponse.builder().programId(id).build();
 	}
 }

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/program/application/service/ProgramService.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/program/application/service/ProgramService.java
@@ -1,5 +1,6 @@
 package com.blackcompany.eeos.program.application.service;
 
+import com.blackcompany.eeos.attend.application.service.CandidateService;
 import com.blackcompany.eeos.program.application.domain.ProgramModel;
 import com.blackcompany.eeos.program.application.dto.CommandProgramResponse;
 import com.blackcompany.eeos.program.application.dto.GetProgramResponse;
@@ -24,12 +25,15 @@ public class ProgramService
 	private final ProgramEntityConverter entityConverter;
 	private final ProgramResponseConverter responseConverter;
 	private final ProgramRepository programRepository;
+	private final CandidateService candidateService;
 
 	@Override
 	public CommandProgramResponse create(AbstractProgramRequest request) {
 		ProgramModel model = requestConverter.from(request);
 		ProgramEntity entity = entityConverter.toEntity(model);
 		ProgramEntity save = programRepository.save(entity);
+
+		candidateService.saveCandidate(save.getId());
 
 		return responseConverter.from(save.getId());
 	}


### PR DESCRIPTION
## 📌 관련 이슈
closed #26 

## ✨ PR 내용
프로그램에 대한 참석자 정보 가져오는 API 구현하였습니다.

우선은 프로그램에 대해서 모든 사용자가 참석 대상자 입니다.
이 부분은 추후 기획상 변경될 여지가 있다고 생각하여 (DefaultCandidateService로 구현하였습니다.)
나중에 기획 변경 생기면 CandidateService를 구현해서 새로운 기획에 맞춰 구현하면 될 것 같습니다.

또한, 지금은 쿼리를 정말 신경쓰지 않았습니다...하핫
그래서 프로그램 저장 시에 attendRepository에 insert 쿼리가 엄청나게 많이 나가요!!!!
이 부분은 ... 고치겠습니다...

또한, AttendInfo를 가져올 때, member를 하나씩 select하고 있는 쿼리도 변경하겠습니다.

위 쿼리 관련 두 부분은 별도의 이슈로 처리하도록 하겠습니다.

DB.... 어렵네요..... 쿼리.. 어렵네요....

