### PR TITLE
[BE/FEAT] 팀빌딩을 종료한다.

### DIFF
--- a/BE/eeos/src/main/java/com/blackcompany/eeos/teamBuilding/application/exception/DeniedEditTeamBuilding.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/teamBuilding/application/exception/DeniedEditTeamBuilding.java
@@ -1,0 +1,18 @@
+package com.blackcompany.eeos.teamBuilding.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+/** 팀빌딩 수정 권한이 없을 때 발생하는 예외 */
+public class DeniedEditTeamBuilding extends BusinessException {
+	private static final String FAIL_CODE = "6005";
+
+	public DeniedEditTeamBuilding() {
+		super(FAIL_CODE, HttpStatus.UNAUTHORIZED);
+	}
+
+	@Override
+	public String getMessage() {
+		return "팀빌딩 수정 권한을 가지고 있지 않습니다.";
+	}
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/teamBuilding/application/exception/NotFoundProgressTeamBuildingException.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/teamBuilding/application/exception/NotFoundProgressTeamBuildingException.java
@@ -1,0 +1,18 @@
+package com.blackcompany.eeos.teamBuilding.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+/** 진행중인 팀빌딩이 존재하지 않을 때 예외 */
+public class NotFoundProgressTeamBuildingException extends BusinessException {
+	private static final String FAIL_CODE = "6002";
+
+	public NotFoundProgressTeamBuildingException() {
+		super(FAIL_CODE, HttpStatus.NOT_FOUND);
+	}
+
+	@Override
+	public String getMessage() {
+		return "진행중인 팀빌딩이 존재하지 않습니다";
+	}
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/teamBuilding/application/model/RestrictTeamBuilding.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/teamBuilding/application/model/RestrictTeamBuilding.java
@@ -2,6 +2,7 @@ package com.blackcompany.eeos.teamBuilding.application.model;
 
 import com.blackcompany.eeos.common.support.AbstractModel;
 import com.blackcompany.eeos.teamBuilding.application.exception.DeniedOverUpperLimitException;
+import com.blackcompany.eeos.teamBuilding.application.exception.NotFoundProgressTeamBuildingException;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,6 +17,7 @@ import lombok.ToString;
 @Builder(toBuilder = true)
 public class RestrictTeamBuilding implements AbstractModel {
 	private static final AtomicLong UPPER_LIMIT = new AtomicLong(1);
+	private static final AtomicLong LOWER_LIMIT = new AtomicLong(0);
 	private AtomicLong totalActiveCount;
 
 	public void addActiveCount() {
@@ -23,13 +25,21 @@ public class RestrictTeamBuilding implements AbstractModel {
 		validateCreation();
 	}
 
+	public void subtractActiveCount() {
+		totalActiveCount.decrementAndGet();
+		validateDeletion();
+	}
+
 	private void validateCreation() {
 		if (totalActiveCount.get() > UPPER_LIMIT.get()) {
-			System.out.println("실패" + totalActiveCount.get());
 			throw new DeniedOverUpperLimitException();
 		}
+	}
 
-		System.out.println("성공" + totalActiveCount.get());
+	private void validateDeletion() {
+		if (totalActiveCount.get() < LOWER_LIMIT.get()) {
+			throw new NotFoundProgressTeamBuildingException();
+		}
 	}
 
 	public static RestrictTeamBuilding of() {

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/teamBuilding/application/model/TeamBuildingModel.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/teamBuilding/application/model/TeamBuildingModel.java
@@ -1,6 +1,7 @@
 package com.blackcompany.eeos.teamBuilding.application.model;
 
 import com.blackcompany.eeos.common.support.AbstractModel;
+import com.blackcompany.eeos.teamBuilding.application.exception.DeniedEditTeamBuilding;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,4 +23,10 @@ public class TeamBuildingModel implements AbstractModel {
 	private int maxTeamSize;
 	private String status;
 	private Long memberId;
+
+	public void validateEdit(Long memberId) {
+		if (!this.memberId.equals(memberId)) {
+			throw new DeniedEditTeamBuilding();
+		}
+	}
 }

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/teamBuilding/application/service/CommandTeamBuildingService.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/teamBuilding/application/service/CommandTeamBuildingService.java
@@ -2,13 +2,16 @@ package com.blackcompany.eeos.teamBuilding.application.service;
 
 import com.blackcompany.eeos.target.application.service.SelectTeamBuildingTargetService;
 import com.blackcompany.eeos.teamBuilding.application.dto.CreateTeamBuildingRequest;
+import com.blackcompany.eeos.teamBuilding.application.exception.NotFoundProgressTeamBuildingException;
 import com.blackcompany.eeos.teamBuilding.application.model.RestrictTeamBuilding;
 import com.blackcompany.eeos.teamBuilding.application.model.TeamBuildingModel;
 import com.blackcompany.eeos.teamBuilding.application.model.converter.TeamBuildingEntityConverter;
 import com.blackcompany.eeos.teamBuilding.application.model.converter.TeamBuildingRequestConverter;
 import com.blackcompany.eeos.teamBuilding.application.usecase.CreateTeamBuildingUsecase;
+import com.blackcompany.eeos.teamBuilding.application.usecase.EndTeamBuildingUsecase;
 import com.blackcompany.eeos.teamBuilding.persistence.TeamBuildingEntity;
 import com.blackcompany.eeos.teamBuilding.persistence.TeamBuildingRepository;
+import com.blackcompany.eeos.teamBuilding.persistence.TeamBuildingStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,12 +19,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class CommandTeamBuildingService implements CreateTeamBuildingUsecase {
+public class CommandTeamBuildingService
+		implements CreateTeamBuildingUsecase, EndTeamBuildingUsecase {
 	private static final RestrictTeamBuilding RESTRICT_TEAM_BUILDING = RestrictTeamBuilding.of();
 
 	private final TeamBuildingRequestConverter requestConverter;
 	private final TeamBuildingEntityConverter entityConverter;
-	private final TeamBuildingRepository repository;
+	private final TeamBuildingRepository teamBuildingRepository;
 	private final SelectTeamBuildingTargetService teamBuildingTargetService;
 
 	@Override
@@ -30,8 +34,23 @@ public class CommandTeamBuildingService implements CreateTeamBuildingUsecase {
 		RESTRICT_TEAM_BUILDING.addActiveCount();
 
 		TeamBuildingModel model = requestConverter.from(memberId, request);
-		TeamBuildingEntity savedEntity = repository.save(entityConverter.toEntity(model));
+		TeamBuildingEntity savedEntity = teamBuildingRepository.save(entityConverter.toEntity(model));
 
 		teamBuildingTargetService.save(savedEntity.getId(), request.getMembers());
+	}
+
+	@Override
+	@Transactional
+	public void delete(Long memberId) {
+		TeamBuildingModel model =
+				teamBuildingRepository
+						.findByStatus(TeamBuildingStatus.PROGRESS)
+						.map(entityConverter::from)
+						.orElseThrow(NotFoundProgressTeamBuildingException::new);
+		model.validateEdit(memberId);
+
+		teamBuildingRepository.delete(entityConverter.toEntity(model));
+
+		RESTRICT_TEAM_BUILDING.subtractActiveCount();
 	}
 }

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/teamBuilding/application/usecase/EndTeamBuildingUsecase.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/teamBuilding/application/usecase/EndTeamBuildingUsecase.java
@@ -1,0 +1,10 @@
+package com.blackcompany.eeos.teamBuilding.application.usecase;
+
+public interface EndTeamBuildingUsecase {
+	/**
+	 * 팀빌딩을 종료한다.
+	 *
+	 * @param memberId 팀빌딩 작성자
+	 */
+	void delete(Long memberId);
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/teamBuilding/persistence/TeamBuildingRepository.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/teamBuilding/persistence/TeamBuildingRepository.java
@@ -1,5 +1,9 @@
 package com.blackcompany.eeos.teamBuilding.persistence;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TeamBuildingRepository extends JpaRepository<TeamBuildingEntity, Long> {}
+public interface TeamBuildingRepository extends JpaRepository<TeamBuildingEntity, Long> {
+
+	Optional<TeamBuildingEntity> findByStatus(TeamBuildingStatus status);
+}

--- a/BE/eeos/src/main/java/com/blackcompany/eeos/teamBuilding/presentation/TeamBuildingController.java
+++ b/BE/eeos/src/main/java/com/blackcompany/eeos/teamBuilding/presentation/TeamBuildingController.java
@@ -7,9 +7,11 @@ import com.blackcompany.eeos.common.presentation.respnose.ApiResponseGenerator;
 import com.blackcompany.eeos.common.presentation.respnose.MessageCode;
 import com.blackcompany.eeos.teamBuilding.application.dto.CreateTeamBuildingRequest;
 import com.blackcompany.eeos.teamBuilding.application.usecase.CreateTeamBuildingUsecase;
+import com.blackcompany.eeos.teamBuilding.application.usecase.EndTeamBuildingUsecase;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,11 +20,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class TeamBuildingController {
 	private final CreateTeamBuildingUsecase createTeamBuildingUsecase;
+	private final EndTeamBuildingUsecase endTeamBuildingUsecase;
 
 	@PostMapping("/team-building")
-	public ApiResponse<SuccessBody<Void>> changeActiveStatus(
+	public ApiResponse<SuccessBody<Void>> create(
 			@Member Long memberId, @RequestBody @Valid CreateTeamBuildingRequest request) {
 		createTeamBuildingUsecase.create(memberId, request);
 		return ApiResponseGenerator.success(HttpStatus.OK, MessageCode.CREATE);
+	}
+
+	@DeleteMapping("/team-building/end")
+	public ApiResponse<SuccessBody<Void>> end(@Member Long memberId) {
+		endTeamBuildingUsecase.delete(memberId);
+		return ApiResponseGenerator.success(HttpStatus.OK, MessageCode.DELETE);
 	}
 }

--- a/BE/eeos/src/test/java/com/blackcompany/eeos/teamBuilding/application/model/TeamBuildingModelTest.java
+++ b/BE/eeos/src/test/java/com/blackcompany/eeos/teamBuilding/application/model/TeamBuildingModelTest.java
@@ -1,0 +1,32 @@
+package com.blackcompany.eeos.teamBuilding.application.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.blackcompany.eeos.teamBuilding.application.exception.DeniedEditTeamBuilding;
+import com.blackcompany.eeos.teamBuilding.fixture.TeamBuildingFixture;
+import com.blackcompany.eeos.teamBuilding.persistence.TeamBuildingStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TeamBuildingModelTest {
+	@Test
+	@DisplayName("해당 팀빌딩에 수정권한이 있는 유저이면 예외가 발생한다.")
+	void cannot_edit() {
+		// given
+		TeamBuildingModel model = TeamBuildingFixture.팀빌딩_모델(TeamBuildingStatus.PROGRESS, 1L);
+
+		// when & then
+		assertThrows(DeniedEditTeamBuilding.class, () -> model.validateEdit(2L));
+	}
+
+	@Test
+	@DisplayName("해당 팀빌딩에 수정권한이 없는 유저이면 예외가 발생하지 않는다.")
+	void can_edit() {
+		// given
+		TeamBuildingModel model = TeamBuildingFixture.팀빌딩_모델(TeamBuildingStatus.PROGRESS, 1L);
+
+		// when & then
+		Assertions.assertDoesNotThrow(() -> model.validateEdit(1L));
+	}
+}

--- a/BE/eeos/src/test/java/com/blackcompany/eeos/teamBuilding/application/service/CommandTeamBuildingServiceTest.java
+++ b/BE/eeos/src/test/java/com/blackcompany/eeos/teamBuilding/application/service/CommandTeamBuildingServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import com.blackcompany.eeos.target.application.service.SelectTeamBuildingTargetService;
 import com.blackcompany.eeos.teamBuilding.application.dto.CreateTeamBuildingRequest;
+import com.blackcompany.eeos.teamBuilding.application.exception.DeniedEditTeamBuilding;
 import com.blackcompany.eeos.teamBuilding.application.model.converter.TeamBuildingEntityConverter;
 import com.blackcompany.eeos.teamBuilding.application.model.converter.TeamBuildingRequestConverter;
 import com.blackcompany.eeos.teamBuilding.fixture.TeamBuildingFixture;
@@ -13,6 +14,8 @@ import com.blackcompany.eeos.teamBuilding.persistence.TeamBuildingEntity;
 import com.blackcompany.eeos.teamBuilding.persistence.TeamBuildingRepository;
 import com.blackcompany.eeos.teamBuilding.persistence.TeamBuildingStatus;
 import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,5 +45,18 @@ class CommandTeamBuildingServiceTest {
 
 		// then
 		verify(teamBuildingTargetService).save(생성한_팀빌딩.getId(), 팀빌딩_생성_요청.getMembers());
+	}
+
+	@Test
+	@DisplayName("진행 중인 팀빌딩의 작성자가 아니라면 수정 권한이 없음 예외가 발생한다.")
+	void denied_edit_team_building() {
+		// given
+		TeamBuildingEntity 생성된_팀빌딩 = TeamBuildingFixture.팀빌딩(TeamBuildingStatus.PROGRESS, 1L);
+		when(teamBuildingRepository.findByStatus(TeamBuildingStatus.PROGRESS))
+				.thenReturn(Optional.of(생성된_팀빌딩));
+
+		// when & then
+		Assertions.assertThrows(
+				DeniedEditTeamBuilding.class, () -> commandTeamBuildingService.delete(2L));
 	}
 }

--- a/BE/eeos/src/test/java/com/blackcompany/eeos/teamBuilding/fixture/TeamBuildingFixture.java
+++ b/BE/eeos/src/test/java/com/blackcompany/eeos/teamBuilding/fixture/TeamBuildingFixture.java
@@ -2,6 +2,7 @@ package com.blackcompany.eeos.teamBuilding.fixture;
 
 import com.blackcompany.eeos.target.fixture.TargetMemberFixture;
 import com.blackcompany.eeos.teamBuilding.application.dto.CreateTeamBuildingRequest;
+import com.blackcompany.eeos.teamBuilding.application.model.TeamBuildingModel;
 import com.blackcompany.eeos.teamBuilding.persistence.TeamBuildingEntity;
 import com.blackcompany.eeos.teamBuilding.persistence.TeamBuildingStatus;
 import java.util.List;
@@ -24,6 +25,17 @@ public class TeamBuildingFixture {
 				.content("content")
 				.maxTeamSize(3)
 				.status(status)
+				.memberId(writerId)
+				.build();
+	}
+
+	public static TeamBuildingModel 팀빌딩_모델(TeamBuildingStatus status, Long writerId) {
+		return TeamBuildingModel.builder()
+				.id(1L)
+				.title("title")
+				.content("content")
+				.maxTeamSize(3)
+				.status(status.getStatus())
 				.memberId(writerId)
 				.build();
 	}


### PR DESCRIPTION
## 📌 관련 이슈
closed #255

## ✨ PR 내용
진행중인 팀빌딩을 종료합니다.
이때, 진행중인 팀빌딩의 갯수를 관리하고 있는 RestrictTeamBuilding 객체가 가지고 있는 totalCount 수를 줄여야 합니다.

하지만, static 클래스이기에 단위 테스트를 진행하기가 어려웠습니다.

따라서, RestrictTeamBuilding 을 애플리케이션 단에서 관리하는 측면의 어려움을 느껴 별도의 DB를 이용하여 리팩터링 하도록 하겠습니다.
#264


## 주의 사항
브랜치 방향 꼭 확인하세요!!!!
